### PR TITLE
Add `with` block to entries()

### DIFF
--- a/src/cmudict/__init__.py
+++ b/src/cmudict/__init__.py
@@ -127,8 +127,9 @@ def symbols_string():
 def vp():
     """Return a list of punctuation pronounciations."""
     cmu_vp = defaultdict(list)
-    for key, value in _entries(vp_stream()):
-        cmu_vp[key].append(value)
+    with vp_stream() as stream:
+        for key, value in _entries(stream):
+            cmu_vp[key].append(value)
     return cmu_vp
 
 


### PR DESCRIPTION
Addresses #120.

This will make calls to `entries()` safe, although any users of `dict_stream()` will still need to manage the returned stream themselves.